### PR TITLE
Remove instructor notes from R tutorials

### DIFF
--- a/content/en/docs/R-time-series-autocorrelation/instructor_notes.md
+++ b/content/en/docs/R-time-series-autocorrelation/instructor_notes.md
@@ -1,6 +1,0 @@
----
-title: "Instructor Notes"
-weight: 4
-description:
----
-

--- a/content/en/docs/R-time-series-data/instructor_notes.md
+++ b/content/en/docs/R-time-series-data/instructor_notes.md
@@ -1,6 +1,0 @@
----
-title: "Instructor Notes"
-weight: 4
-description:
----
-

--- a/content/en/docs/R-time-series-decomposition/instructor_notes.md
+++ b/content/en/docs/R-time-series-decomposition/instructor_notes.md
@@ -1,6 +1,0 @@
----
-title: "Instructor Notes"
-weight: 4
-description:
----
-

--- a/content/en/docs/R-time-series-modeling/instructor_notes.md
+++ b/content/en/docs/R-time-series-modeling/instructor_notes.md
@@ -1,6 +1,0 @@
----
-title: "Instructor Notes"
-weight: 4
-description:
----
-


### PR DESCRIPTION
R tutorials don't typically have separate instructor notes.