### PR TITLE
Add additional documentation for teachers and self-guided learners

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -16,6 +16,9 @@ main:
   - name: Syllabus
     url: syllabus/
     weight: 40
+  - name: Getting Started
+    url: getting-started/
+    weight: 50
   - name: About
     url: about/
-    weight: 50
+    weight: 60

--- a/content/about/audience.md
+++ b/content/about/audience.md
@@ -1,0 +1,20 @@
+---
+title: "Audience"
+type: page
+summary: "Description of people this material is intended for"
+---
+
+The long-term goal of this site is to help two large groups of people: 1) Students in a classroom at a college or university; and 2) Free-range learners, or folks who aren’t taking a formal class and are interested in learning online on their own time.
+We are starting with the classroom students and then attempting to build on the material generated to make it maximally useful to the broader audience of folks who want to learn about ecological forecasting and dynamics.
+
+* The material is designed to be accessible to graduate students and advanced undergraduates
+* It assumes a basic ability to read and engage with the primary scientific literature, but provides guidance for engaging with each paper to help students who are learning how to do this
+* It assumes a basic understanding of R, including loading tabular data, working with variables, loading packages, and running functions. Some experience with `dplyr` and `ggplot2` is also helpful. If you need a basic introduction to R we recommend checking out the Data Carpentry lesson materials on [Data Analysis and Visualization in R for Ecologists](https://datacarpentry.org/R-ecology-lesson/).
+
+Examples of folks who we are trying to help:
+
+Maya: An advanced undergraduate in natural resources who wants to understand what ecological forecasting is and how it might be applied in conservation and management. She has used basic R in some of her other courses and has just started reading the primary scientific literature in a classroom context.
+
+Juniper: A graduate student with a thesis related to how populations change through time, but who doesn't know anything about how to model time-series. They want to learn how to build and analyze time-series models for their thesis projects and find the idea of forecasting interesting.
+
+Jaylen: A professor who understands that ecological forecasting is becoming important for students to learn and wants to develop either a full course or a seminar on the topic. He understands the main concepts, but doesn't know what the best papers would be best for teaching and doesn't have the time to develop a bunch of R tutorials.

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,10 +1,13 @@
 ---
 title: About the course
 linkTitle: About
+type: page
 ---
 
 This is a course on how ecological systems change through time and how to forecast how they will change in the future.
 It combines reading and discussing primary scientific literature with R tutorials on how to work with time-series data and make forecasts in R.
+It is intended for graduate students and advanced undergraduates who have started reading the primary scientific literature and have a basic background in R. More details about the intended audience are available on the [Audience page](audience)
+
 It is taught each Fall at the University of Florida by Drs. Morgan Ernest and Ethan White.
 The full course including lecture notes and R tutorials is openly available on this site so that anyone can learn these important approaches and skills for themselves.
 Course materials are openly licensed and <a href="https://github.com/weecology/forecasting-course">developed on GitHub</a>.

--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -1,35 +1,58 @@
-[![DOI](https://zenodo.org/badge/283032599.svg)](https://zenodo.org/badge/latestdoi/283032599)
+---
+title: "Getting Started"
+weight: 26
+---
 
-# Ecological Forecasting & Dynamics Course
+{{< toc >}}
 
-This is a course on how ecological systems change through time and how to forecast how they will change in the future.
-It combines reading and discussing primary scientific literature with R tutorials on how to work with time-series data and make forecasts in R.
-It is taught each Fall at the University of Florida by Drs. Morgan Ernest and Ethan White.
-The full course including lecture notes and R tutorials is openly available so that students can learn these important approaches and skills for themselves and so that other teachers can reuse and remix the content of the course.
+## Self-Guided Learning About Ecological Forecasting & Dynamics
 
-## Getting Started
+There are two primary sets of information on this site:
+1. The background and conceptual foundation for ecological forecasting and dynamics, which focuses on reading and engaging with the primary scientific literature.
+2. The computational tools for working with, modeling, and making forecasts from (mostly time-series) data.
 
-### Using Materials to Learn About Ecological Forecasting
+The original design of this course material is that two sets of information are taught in the integrated manner shown on the [Schedule page](../schedule).
+Where possible the conceptual material is paired with related material in R.
 
-To use the materials for learning we recommend viewing them through [the rendered website](https://course.naturecast.org). Check out the [Getting Started page](https://course.naturecast.org/getting-started) to find out how to best use the site for independent learning.
+While taking a self-guided approach to the material you can either follow this general approach by following the order of the [Schedule page](../schedule) or choose to focus on either of the components in isolation.
 
-### Using Materials to Teach Ecological Forecasting
+### Self-Guided Learning - Conceptual Material
+
+For the background and conceptual material we recommend that self-guided learners first read the Discussion Questions page for the lesson to get an idea of what they should be learning from the paper.
+Then read the paper itself, trying to develop your own answers to the Discussion Questions.
+Finally read through the Instructors Notes page for the lesson to see what we thought were the key take homes from the paper.
+Don't worry if you didn't get all of them yourself, that's part of the learning process.
+
+### Self-Guided Learning - R Material
+
+The R material is generally sequential with most lessons building on previous lessons.
+As such we recommend following the R material in the order present on the [Schedule page](../schedule).
+
+To start an R lesson go the the Material page for the lesson to find any data or packages you will need for the tutorial. 
+The R material is available in two formats - written notes and video.
+We recommend choosing the format you prefer and following along with the tutorial by typing and running the code yourself each step of the way.
+There are also periodic stopping points to allow learners to practice the material on their own.
+We recommend stopping at these points, trying the exercise, and then proceeding to see if your approach matches those present in the notes and videos.
+Once you've finished the tutorial it can be useful to practice the approaches learned on your own data or another similar dataset.
+
+## Teaching Ecological Forecasting & Dynamics
 
 All of the code, lesson content, data, and infrastructure for this site is openly licensed so you can use any of it in your own courses.
 
-Lesson material can be accessed from [the website](https://course.naturecast.org) or using the raw markdown files in the [`content/lessons` directory](https://github.com/weecology/forecasting-course/tree/main/content/lessons) of this repository. Each lesson is stored in it's own named subdirectory. 
+Lesson material can be accessed from this website or using the raw markdown files in the associated [GitHub repository](https://github.com/weecology/forecasting-course).
+The core lesson material is stored in the [`content/lessons` directory](https://github.com/weecology/forecasting-course/tree/main/content/lessons) of the GitHub repository and each lesson is stored in it's own named subdirectory. 
 
 There are three general approaches to using the material in teaching:
 
 1. Use the existing website by linking to one or more lessons from your course site and reading the associated instructors material
 2. Copy material from either the website or this GitHub repository and place it on your own site. You can modify this version however you would like (or leave it unchanged), just provide a link back to the original version for attribution.
-3. Create a copy of the full website and (optionally) modify the lessons and/or change which lessons are included. More information on how to do this is provided in the rest of the README.
+3. Create a copy of the full website and (optionally) modify the lessons and/or change which lessons are included. More information on how to do this is provided below.
 
-## Installation
+### Creating a Copy of the Course Website
 
 The course website is written in Hugo using the [Wowchemy Documentation theme](https://github.com/wowchemy/hugo-documentation-theme) and broader [Wowchemy system](https://wowchemy.com/)
 
-### Netlify
+#### Netlify
 
 The easiest way to create your own version of the course is the create a deployed course on Netlify via this template. You need a GitHub account to do this.
 
@@ -43,7 +66,7 @@ Edit `config/_default/params.yaml` to match your version of course.
 In particular update the repository url to match the new repository you created.
 This will ensure that the `Edit this page` links on each page direct you to your version of the material.
 
-### Locally
+#### Locally
 
 Building a Hugo site locally requires that Go, git, NodeJS, and Hugo all be installed.
 Detailed instructions for all operating systems are available on the [Wowchemy - Edit on your PC with Hugo Extended page](https://wowchemy.com/docs/getting-started/install-hugo-extended/).
@@ -60,14 +83,14 @@ You can build the site locally in the terminal from the root directory of this r
 hugo server
 ```
 
-## Modifying the Site
+### Modifying the Site
 
 * Most content is stored in one folder per lesson in the [`content/lessons` folder](https://github.com/weecology/forecasting-course/tree/main/content/lessons)
 * To add a new lesson make a copy of the [lesson template folder](https://github.com/weecology/forecasting-course/tree/main/content/lessons/LessonTemplate) and modifying the pages in the resulting folder using [markdown](https://www.markdownguide.org/)
 * To modify a lesson edit the markdown files in that lesson folder with the appropriate name. If you followed the instructions on installing on Netlify above, the easiest way to do this is to go to the page you want to edit on the deployed site and click the `Edit this page` link at the bottom.
 * To modify the schedule edit `content/schedule/schedule.md`. In the `lessons` section list the titles of the lessons you want to teach in the order you want to teach them. If you want to include specific dates for each lesson then edit the `dates` section to include those dates in the same order.
 
-## Contributing
+### Contributing
 
 Contributions are always welcome!
 


### PR DESCRIPTION
The one major request in our JOSS review was the addition or more documentation of the target audience and how that audience should use the material. This PR adds info to the README and the website on how to use the website for both self-guided learners and instructors using the material in their own courses. It also adds an audience page describing the types of learners/instructors and the necessary prerequisit background for the material.