### PR TITLE
Add additional links to Dietze Ch 2

### DIFF
--- a/content/lessons/uncertainty/material.md
+++ b/content/lessons/uncertainty/material.md
@@ -9,4 +9,7 @@ editable: true
 
 ## Reading
 
-[Ecological Forecasting: Chapter 2](https://ebookcentral.proquest.com/lib/UFL/detail.action?docID=4866481#goto_toc)
+Ecological Forecasting: Chapter 2
+* [via JSTOR](https://doi.org/10.2307/j.ctvc7796h.6) (not all institutions will have access)
+* [For UF students via the UF eBook library](https://ebookcentral.proquest.com/lib/UFL/detail.action?docID=4866481#goto_toc)
+* [Purchase the book](https://press.princeton.edu/books/hardcover/9780691160573/ecological-forecasting)


### PR DESCRIPTION
The original link only worked for UF students. This adds links to JSTOR for the chapter and Princeton University Press to purchase the book.

Fixes #23