### PR TITLE
Replace "Material" with more specific names

### DIFF
--- a/content/lessons/R-evaluating-forecasts/material.md
+++ b/content/lessons/R-evaluating-forecasts/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Data & Software"
 weight: 1
 type: book
 summary: Software installation requirements

--- a/content/lessons/R-intro-to-forecasting/material.md
+++ b/content/lessons/R-intro-to-forecasting/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Data & Software"
 weight: 1
 type: book
 summary: Software installation requirements

--- a/content/lessons/R-species-distribution-models/material.md
+++ b/content/lessons/R-species-distribution-models/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Data & Software"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/R-state-space-models-1/material.md
+++ b/content/lessons/R-state-space-models-1/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Data & Software"
 weight: 1
 type: book
 summary: Software installation requirements
@@ -7,7 +7,7 @@ show_date: false
 editable: true
 ---
 
-## Software Installation
+## Data & Software
 
 * [Install JAGS](https://sourceforge.net/projects/mcmc-jags/files/)
 * Install the `rjags` R package: `install.packages('rjags')`

--- a/content/lessons/R-time-series-autocorrelation/material.md
+++ b/content/lessons/R-time-series-autocorrelation/material.md
@@ -1,11 +1,12 @@
 ---
-title: "Material"
+title: "Data & Software"
 weight: 1
 type: book
 summary: " "
 show_date: false
 editable: true
 ---
+
 Before doing the lesson:
 * Make sure you have the Portal time series data from last week available on your computer.
 * No new packages need to be installed for this week

--- a/content/lessons/R-time-series-data/material.md
+++ b/content/lessons/R-time-series-data/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Data & Software"
 weight: 1
 summary: " "
 type: book

--- a/content/lessons/R-time-series-decomposition/material.md
+++ b/content/lessons/R-time-series-decomposition/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Data & Software"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/R-time-series-modeling/material.md
+++ b/content/lessons/R-time-series-modeling/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Data & Software"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/community-dynamics/material.md
+++ b/content/lessons/community-dynamics/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/course-wrap-up/material.md
+++ b/content/lessons/course-wrap-up/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/data-driven-forecasts/material.md
+++ b/content/lessons/data-driven-forecasts/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading & Video"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/election-forecasts/material.md
+++ b/content/lessons/election-forecasts/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/ethics/material.md
+++ b/content/lessons/ethics/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/hurricane-forecasts/material.md
+++ b/content/lessons/hurricane-forecasts/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/intro-to-forecasting/material.md
+++ b/content/lessons/intro-to-forecasting/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading & Video"
 weight: 1
 type: book
 summary: Introductory video, reading on ecological forecasting, and reading on general forecasting.

--- a/content/lessons/iterative-forecasting/material.md
+++ b/content/lessons/iterative-forecasting/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/paleo-dynamics/material.md
+++ b/content/lessons/paleo-dynamics/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/phenology/material.md
+++ b/content/lessons/phenology/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/range-shifts/material.md
+++ b/content/lessons/range-shifts/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/scenarios/material.md
+++ b/content/lessons/scenarios/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/species-distribution-models/material.md
+++ b/content/lessons/species-distribution-models/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/state-space-models/material.md
+++ b/content/lessons/state-space-models/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "

--- a/content/lessons/uncertainty/material.md
+++ b/content/lessons/uncertainty/material.md
@@ -1,5 +1,5 @@
 ---
-title: "Material"
+title: "Reading"
 weight: 1
 type: book
 summary: " "


### PR DESCRIPTION
There has been some confusion to what the links to "Material" related to on the site. This replaces that generic title with more specific titles including Reading, Reading & Video, and Data & Software.

Addresses https://github.com/openjournals/jose-reviews/issues/198#issuecomment-1484400890