### PR TITLE
Get the audience page to render while fixing presentation

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -14,3 +14,5 @@ Course materials are openly licensed and <a href="https://github.com/weecology/f
 Anyone is welcome to use the material in their own courses and contributions are always welcome.
 
 Work on this course was supported by the National Science Foundation through grant 1929730 to S.K.M. Ernest and E.P. White, the Gordon and Betty Moore Foundation’s Data-Driven Discovery Initiative through grant GBMF4563 to E.P. White, and the University of Florida. Thanks to Claire Williams and Kelley Graff for their work scheduling and managing courses at UF and especially to Eric Hellgren for providing us the time to make the course openly available. Also, many thanks to our students over the last 7 years for their enthusiasm in learning about ecological forecasting and openness in providing feedback that has helped us improve the course with every iteration.
+<br>
+<br>

--- a/content/about/audience.md
+++ b/content/about/audience.md
@@ -1,7 +1,7 @@
 ---
 title: "Audience"
 type: page
-summary: "Description of people this material is intended for"
+summary: "Description of intended audience for this material"
 ---
 
 The long-term goal of this site is to help two large groups of people: 1) Students in a classroom at a college or university; and 2) Self-guided learners, or folks who aren’t taking a formal class and are interested in learning online on their own time.


### PR DESCRIPTION
The rending of the audience child page on the about page had been cramped. The existing fix of using `index.md` instead of `_index.md` for the about folder caused the page not to be rendered at all. This fixes that while keeping a nice presentation by manually adding line breaks.