### PR TITLE
Replace use of "stakeholder"

### DIFF
--- a/content/lessons/intro-to-forecasting/instructor_notes.md
+++ b/content/lessons/intro-to-forecasting/instructor_notes.md
@@ -39,7 +39,7 @@ editable: true
 
 > How should we think about what to forecast in ecology?
 
-* Talk to stake holders
+* Talk to those who need or are impacted by the forecast
 * Consider whether we have the data/models we need
 
 ## Terminology

--- a/content/lessons/scenarios/_index.md
+++ b/content/lessons/scenarios/_index.md
@@ -13,7 +13,7 @@ editable: true
 **Learning Objectives:**
 * Define and describe scenario based forecasting methods and their uses
 * Distinguish between scenario planning, predictions, and forecasting
-* Describe approaches to multi-stakeholder decision making using scenarios  
+* Describe approaches to multi-group decision making using scenarios  
 
 {{% /callout %}}
 

--- a/content/lessons/scenarios/instructor_notes.md
+++ b/content/lessons/scenarios/instructor_notes.md
@@ -28,7 +28,7 @@ editable: true
 
 * Identify strategies for different possible futures
 * Be prepared to respond to different possible futures and respond if unexpected scenarios occur
-* Actively engage stake-holders in planning and decision making processes in ways that create awareness of future changes
+* Actively engage those using and impacted by the forecasts in planning and decision making processes in ways that create awareness of future changes
 * Good for systematic planning in uncertain situations
 * Allows consideration of different decisions leading to different outcomes
 * Actively recognizes uncertainty/surprises


### PR DESCRIPTION
This term is increasingly being reconsidered in light of it's negative historical usage. See, e.g.,

* https://www.fasttrackimpact.com/post/why-we-shouldn-t-banish-the-word-stakeholder?postId=1a6b9631-56a5-416e-a796-86d6dfb30d87
* https://researchimpact.ca/featured/switching-from-stakeholder/

This replaces the usage for all but the Ethics material, where the word is actively used throughout the reading. An issue has been opened to address if more actively there:

https://github.com/weecology/forecasting-course/issues/53

Thanks to the Ecological Forecasting Initiative DEI group, for
their discussion that precipitated this change.