### PR TITLE
Fix namespace conflicts and variable inconsistencies in Species Distribution Models tutorial

### DIFF
--- a/content/lessons/R-evaluating-forecasts/r_tutorial.md
+++ b/content/lessons/R-evaluating-forecasts/r_tutorial.md
@@ -40,6 +40,7 @@ library(tsibble)
 library(fable)
 library(feasts)
 library(dplyr)
+library(ggplot2)
 ```
 
 * Load the data

--- a/content/lessons/R-species-distribution-models/r_tutorial.md
+++ b/content/lessons/R-species-distribution-models/r_tutorial.md
@@ -132,7 +132,7 @@ points(present_loc, pch='+', cex = 0.5)
 
 ```r
 plot(predictions > 0.5, ext = extent(-140, -50, 25, 60))
-points(present, pch='+', cex = 0.5)
+points(present_loc, pch='+', cex = 0.5)
 ```
 
 * Different thresholds often have better characteristics depending on what we value
@@ -141,7 +141,7 @@ points(present, pch='+', cex = 0.5)
 
 ```r
 plot(predictions > 0.25, ext = extent(-140, -50, 25, 60))
-points(present, pch='+', cex = 0.5)
+points(present_loc, pch='+', cex = 0.5)
 ```
 
 ## Evaluate the model performance
@@ -191,7 +191,7 @@ plot(evaluation, 'ROC')
 ```r
 thresh <- threshold(evaluation, stat = 'prevalence')
 plot(predictions > thresh, ext = extent(-140, -50, 25, 60))
-points(present, pch='+', cex = 0.5)
+points(present_loc, pch='+', cex = 0.5)
 ```
 
 ## Make forecasts

--- a/content/lessons/R-species-distribution-models/r_tutorial.md
+++ b/content/lessons/R-species-distribution-models/r_tutorial.md
@@ -78,7 +78,7 @@ plot(env_data_current$precip)
 
 ```r
 hooded_warb_data = env_data_current |>
-  extract(select(hooded_warb_data, lon, lat)) |>
+  terra::extract(dplyr::select(hooded_warb_data, lon, lat)) |>
   bind_cols(hooded_warb_data)
 ```
 
@@ -120,7 +120,7 @@ summary(logistic_regr_model)
 
 ```r
 predictions <- predict(env_data_current, logistic_regr_model, type = "response")
-present_loc <- select(filter(hooded_warb_data, present == 1), lon, lat)
+present_loc <- dplyr::select(filter(hooded_warb_data, present == 1), lon, lat)
 plot(predictions, ext = extent(-140, -50, 25, 60))
 points(present_loc, pch='+', cex = 0.5)
 ```


### PR DESCRIPTION

I encountered a few errors while running the "R: Species Distribution Models" tutorial and have applied the following fixes:

- Resolved Namespace Conflicts: Explicitly called terra::extract() and dplyr::select() to prevent masking errors. The tutorial previously crashed here because dplyr masked the spatial functions.

- Fixed Variable Inconsistency: Standardized the location data variable. The code previously referenced present in the plotting section, but the variable was defined as present_loc during extraction. I have updated it to use present_loc consistently.

These changes allow the tutorial to run start-to-finish without interruption.